### PR TITLE
Lock sponsor logo aspect ratio (_sponsor.scss)

### DIFF
--- a/web/themes/custom/badcamp_2018/sass/components/_sponsor.scss
+++ b/web/themes/custom/badcamp_2018/sass/components/_sponsor.scss
@@ -2,7 +2,25 @@
   &.node--view-mode-sponsor-logo{
     a{
       display: block;
+      width: 100%;
+      position: relative;
+      height: 0;
+      padding: 56.25% 0 0 0;
+      overflow: hidden;
       margin: 1rem 0;
+      > img {
+        position: absolute;
+        display: block;
+        max-width: 100%;
+        max-height: 100%;
+        width: auto;
+        height: auto;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        margin: auto;
+      }
     }
   }
 }


### PR DESCRIPTION
When square and horizontal logos are mixed in a responsive grid that only takes the grid width into account, square logos like DDEV look disproportionately large next to horizontal logos like Pantheon and Platform in smaller viewports. This code locks all logos into a 16:9 space, keeping them visually consistent.

So this...
<img width="468" alt="screen shot 2018-08-29 at 5 17 11 pm" src="https://user-images.githubusercontent.com/984057/44819047-dde27600-abb0-11e8-9cd6-0a23deecd8e2.png">

Becomes this... 
<img width="467" alt="screen shot 2018-08-29 at 5 16 59 pm" src="https://user-images.githubusercontent.com/984057/44819050-e3d85700-abb0-11e8-90f3-09b029a39980.png">
