### PR TITLE
Add Session Speakers to Schedule, change Sort of Sponsor Members, and Export Twitter View Configs

### DIFF
--- a/config/core.entity_view_display.node.session.schedule.yml
+++ b/config/core.entity_view_display.node.session.schedule.yml
@@ -31,7 +31,7 @@ bundle: session
 mode: schedule
 content:
   field_session_description:
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       trim_length: 600
@@ -40,7 +40,7 @@ content:
     region: content
   field_session_track:
     type: entity_reference_label
-    weight: 0
+    weight: 1
     region: content
     label: hidden
     settings:
@@ -48,15 +48,23 @@ content:
     third_party_settings: {  }
   field_skill_level:
     type: entity_reference_label
-    weight: 1
+    weight: 2
     region: content
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
+  field_speakers:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
   field_venue:
     type: entity_reference_label
-    weight: 2
+    weight: 3
     region: content
     label: hidden
     settings:
@@ -68,7 +76,6 @@ hidden:
   field_session_files: true
   field_session_status: true
   field_session_video: true
-  field_speakers: true
   field_sponsors: true
   field_stick_to_top_of_date: true
   field_stick_to_top_of_schedule: true

--- a/config/core.entity_view_display.node.session.teaser.yml
+++ b/config/core.entity_view_display.node.session.teaser.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.session.field_sponsors
     - field.field.node.session.field_stick_to_top_of_date
     - field.field.node.session.field_stick_to_top_of_schedule
+    - field.field.node.session.field_timeslot
     - field.field.node.session.field_twitter_teaser
     - field.field.node.session.field_venue
     - node.type.session
@@ -32,7 +33,7 @@ mode: teaser
 content:
   field_session_description:
     type: text_summary_or_trimmed
-    weight: 2
+    weight: 4
     region: content
     label: hidden
     settings:
@@ -54,7 +55,7 @@ content:
         class: margin-vertical-1
   field_skill_level:
     type: entity_reference_label
-    weight: 0
+    weight: 2
     region: content
     label: hidden
     settings:
@@ -62,18 +63,33 @@ content:
     third_party_settings:
       field_formatter_class:
         class: margin-vertical-1
+  field_speakers:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_venue:
+    type: entity_reference_label
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
 hidden:
   field_date: true
   field_display_title: true
   field_session_files: true
   field_session_status: true
   field_session_video: true
-  field_speakers: true
   field_sponsors: true
   field_stick_to_top_of_date: true
   field_stick_to_top_of_schedule: true
+  field_timeslot: true
   field_twitter_teaser: true
-  field_venue: true
   flag_add_to_schedule: true
   flag_interested: true
   links: true

--- a/config/views.view.attendees.yml
+++ b/config/views.view.attendees.yml
@@ -293,6 +293,7 @@ display:
         filter_groups: false
         relationships: false
         arguments: false
+        sorts: false
       filters:
         status:
           value: '1'
@@ -382,8 +383,9 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: node_nid
+      sorts: {  }
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/config/views.view.twitter_teasers.yml
+++ b/config/views.view.twitter_teasers.yml
@@ -9,6 +9,7 @@ dependencies:
     - user.role.administrator
   module:
     - node
+    - options
     - user
 id: twitter_teasers
 label: 'Twitter Teasers for AmyJune'
@@ -468,6 +469,55 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
+        field_session_status_value:
+          id: field_session_status_value
+          table: node__field_session_status
+          field: field_session_status_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            accepted: accepted
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_session_status_value_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: field_session_status_value_op
+            identifier: field_session_status_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              sponsor: '0'
+              sponsor_manager: '0'
+              event_manager: '0'
+              session_manager: '0'
+              summit_manager: '0'
+              training_manager: '0'
+              volunteer: '0'
+              volunteer_manager: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
       sorts:
         created:
           id: created

--- a/web/themes/custom/badcamp_2018/templates/content/node--session--schedule.html.twig
+++ b/web/themes/custom/badcamp_2018/templates/content/node--session--schedule.html.twig
@@ -82,9 +82,9 @@
         {{ title_suffix }}
 
         <div class="info">
+            {{ content.field_speakers }}
             {{ content.field_session_track }}
             {{ content.field_skill_level }}
-            {{ content.field_speakers }}
         </div>
 
         <div class="info">


### PR DESCRIPTION
Add and Re-Order Session Speakers on the Schedule, change Sort of Sponsor Members to use Delta, and Export of Twitter View to achieve Clean Configs.